### PR TITLE
Rename the package to Blueprint

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,25 +3,25 @@
 import PackageDescription
 
 let package = Package(
-    name: "Collection",
+    name: "Blueprint",
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "Collection",
-            targets: ["Collection"]),
+            name: "Blueprint",
+            targets: ["Blueprint"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        // We need to add the thrift 
+        .package(url: "https://github.com/guardian/thrift-swift.git", .upToNextMinor(from: "0.14.0-gu6"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "Collection",
-            dependencies: []),
+            name: "Blueprint",
+            dependencies: ["Thrift"]),
         .testTarget(
-            name: "CollectionTests",
-            dependencies: ["Collection"]),
+            name: "BlueprintTests",
+            dependencies: ["Blueprint"]),
     ]
 )


### PR DESCRIPTION
This avoids collisions with the native Collection type.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This changes the package name to Blueprint. This avoids a namespace collision that can't be resolved. The compiler was unable to resolve the collision with the Swift native type `Collection` and this Packages class `Collection`.   This would normally be resolved by using the package name as a prefix, but because the package was also named `Collection`, the compiler isn't able to resolve this.

This PR also adds the guardian thrift package as a dependency. This is required because the generated +Exts file imports Thrift, so we need to add it.

Finally, this change will require a change to the automated script that generates the swift files to put them in a new location `sources/Blueprint`

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
